### PR TITLE
Scripted PR to add .dockerignore file if missing, or update an existing .dockerignore

### DIFF
--- a/.github/actions/pipeline/.dockerignore
+++ b/.github/actions/pipeline/.dockerignore
@@ -1,0 +1,9 @@
+**/.git
+**/.gitignore
+**/.circleci/
+**/.gitlab-ci.*
+**/.env*
+**/docker-compose*
+Dockerfile*
+.dockerignore
+Jenkinsfile


### PR DESCRIPTION

SUMMARY
Add .dockerignore file if missing, or update existing .dockerignore
A scripted PR created by DevOps team
